### PR TITLE
Custom exceptions separator and case insensitive exceptions

### DIFF
--- a/dist/jquery.hypher.js
+++ b/dist/jquery.hypher.js
@@ -9,6 +9,7 @@ var module = {
  */
 function Hypher(language) {
     var exceptions = [],
+        exceptionsSeparator = '-',
         i = 0;
     /**
      * @type {!Hypher.TrieNode}
@@ -33,10 +34,12 @@ function Hypher(language) {
     this.exceptions = {};
 
     if (language['exceptions']) {
-        exceptions = language['exceptions'].split(/,\s?/g);
+        exceptions = language['exceptions'].split(/,\s*/g);
+        if (language['exceptionsSeparator']) exceptionsSeparator = language['exceptionsSeparator'];
 
         for (; i < exceptions.length; i += 1) {
-            this.exceptions[exceptions[i].replace(/-/g, '')] = exceptions[i].split('-');
+            var wordSplit = exceptions[i].toLowerCase().split(exceptionsSeparator);
+            this.exceptions[wordSplit.join('')] = wordSplit;
         }
     }
 }
@@ -145,8 +148,18 @@ Hypher.prototype.hyphenate = function (word) {
         trie = this.trie,
         result = [''];
 
-    if (this.exceptions.hasOwnProperty(word)) {
-        return this.exceptions[word];
+    // Make exceptions work case insensitive.
+    if (this.exceptions.hasOwnProperty(word.toLowerCase())) {
+      var exceptionArray = this.exceptions[word.toLowerCase()];
+      var wordArray = [];
+
+      var index = 0;
+      for (i = 0; i < exceptionArray.length; i++) {
+        wordArray.push(word.substr(index, exceptionArray[i].length));
+        index += exceptionArray[i].length;
+      }
+
+      return wordArray;
     }
 
     if (word.indexOf('\u00AD') !== -1) {

--- a/examples/jquery/en-us.js
+++ b/examples/jquery/en-us.js
@@ -21,7 +21,9 @@ module.exports = {
 		10 : "se1mi6t5ic3tro1le1um5sa3par5iloli3gop1o1am1en3ta5bath3er1o1s3slova1kia3s2og1a1myo3no2t1o3nc2tro3me6c1cu2r1ance5noc3er1osth1o5gen1ih3i5pel1a4nfi6n3ites_ever5si5bs2s1a3chu1d1ri3pleg5_ta5pes1trproc3i3ty_s5sign5a3b3rab1o1loiitin5er5arwaste3w6a2mi1n2ut1erde3fin3itiquin5tes5svi1vip3a3r",
 		11 : "pseu3d6o3f2s2t1ant5shimi1n2ut1estpseu3d6o3d25tab1o1lismpo3lyph1onophi5lat1e3ltravers3a3bschro1ding12g1o4n3i1zat1ro1pol3it3trop1o5lis3trop1o5lesle3g6en2dreeth1y6l1eneor4tho3ni4t",
 		12 : "3ra4m5e1triz1e6p3i3neph1"
-	}
+	},
+	'exceptions': "",
+	'exceptionsSeparator': "*"
 };
 var h = new window['Hypher'](module.exports);
 

--- a/lib/hypher.js
+++ b/lib/hypher.js
@@ -4,6 +4,7 @@
  */
 function Hypher(language) {
     var exceptions = [],
+        exceptionsSeparator = '-',
         i = 0;
     /**
      * @type {!Hypher.TrieNode}
@@ -28,10 +29,12 @@ function Hypher(language) {
     this.exceptions = {};
 
     if (language['exceptions']) {
-        exceptions = language['exceptions'].split(/,\s?/g);
+        exceptions = language['exceptions'].split(/,\s*/g);
+        if (language['exceptionsSeparator']) exceptionsSeparator = language['exceptionsSeparator'];
 
         for (; i < exceptions.length; i += 1) {
-            this.exceptions[exceptions[i].replace(/-/g, '')] = exceptions[i].split('-');
+            var wordSplit = exceptions[i].toLowerCase().split(exceptionsSeparator);
+            this.exceptions[wordSplit.join('')] = wordSplit;
         }
     }
 }
@@ -140,8 +143,18 @@ Hypher.prototype.hyphenate = function (word) {
         trie = this.trie,
         result = [''];
 
-    if (this.exceptions.hasOwnProperty(word)) {
-        return this.exceptions[word];
+    // Make exceptions work case insensitive.
+    if (this.exceptions.hasOwnProperty(word.toLowerCase())) {
+      var exceptionArray = this.exceptions[word.toLowerCase()];
+      var wordArray = [];
+
+      var index = 0;
+      for (i = 0; i < exceptionArray.length; i++) {
+        wordArray.push(word.substr(index, exceptionArray[i].length));
+        index += exceptionArray[i].length;
+      }
+
+      return wordArray;
     }
 
     if (word.indexOf('\u00AD') !== -1) {


### PR DESCRIPTION
LS,

Thanks for the great script! I added 2 alterations:
1. Custom exception separator: the original Hypher uses a dash for exception separator to show where a word may be soft hyphened. All the exception separators are automatically replaced by soft hyphens, but some words contain a dash which should stay a dash, ie. the Dutch word "hotel-restaurant". By adding a custom exception separator like "_" the exception could look like "ho_tel-res_tau_rant".
2. The orginal Hypher needs all case variations of exceptions defined, ie. "Probably", "PROBABLY" and "probably". My 2nd alteration stores the lowercase version of the exception and compares this with a lowercase version of words in the to-be-hyphenated text. In case of a match, Hypher now loops through the syllabes and gets substrings of the to-be-hyphenated word to retain the original case.

I hope you like these additions!

Cheers, Laurens
